### PR TITLE
refactor: make PCA raw trainable

### DIFF
--- a/java-ml/src/main/java/org/rsultan/core/clustering/ensemble/isolationforest/IsolationForest.java
+++ b/java-ml/src/main/java/org/rsultan/core/clustering/ensemble/isolationforest/IsolationForest.java
@@ -5,9 +5,12 @@ import static org.rsultan.core.clustering.ensemble.isolationforest.utils.ScoreUt
 
 import java.util.List;
 import java.util.stream.DoubleStream;
+import java.util.stream.LongStream;
 import org.apache.commons.lang3.RandomUtils;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.indexing.INDArrayIndex;
+import org.nd4j.linalg.indexing.NDArrayIndex;
 import org.nd4j.linalg.ops.transforms.Transforms;
 import org.rsultan.core.Trainable;
 import org.rsultan.dataframe.Column;
@@ -44,9 +47,11 @@ public class IsolationForest implements Trainable<IsolationForest> {
     int treeDepth = (int) Math.ceil(Math.log(realSample) / Math.log(2));
     isolationTrees = range(0, nbTrees).parallel()
         .peek(i -> LOG.info("Tree number: {}", i))
-        .mapToObj(i -> range(0, realSample)
-            .map(idx -> RandomUtils.nextInt(0, matrix.rows()))
-            .toArray()).map(matrix::getRows)
+        .mapToObj(i -> LongStream.range(0, realSample)
+            .map(idx -> RandomUtils.nextLong(0, matrix.rows()))
+            .toArray())
+        .map(NDArrayIndex::indices)
+        .map(matrix::get)
         .map(m -> new IsolationTree(treeDepth).train(m))
         .toList();
     return this;

--- a/java-ml/src/main/java/org/rsultan/core/clustering/ensemble/isolationforest/IsolationTree.java
+++ b/java-ml/src/main/java/org/rsultan/core/clustering/ensemble/isolationforest/IsolationTree.java
@@ -1,12 +1,13 @@
 package org.rsultan.core.clustering.ensemble.isolationforest;
 
-import static java.util.stream.IntStream.range;
+import static java.util.stream.LongStream.range;
 import static org.apache.commons.lang3.RandomUtils.nextDouble;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
 import static org.rsultan.core.clustering.ensemble.isolationforest.utils.ScoreUtils.averagePathLength;
 
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.indexing.NDArrayIndex;
 import org.rsultan.core.RawTrainable;
 import org.rsultan.core.clustering.ensemble.domain.IsolationNode;
 import org.slf4j.Logger;
@@ -45,12 +46,12 @@ public class IsolationTree implements RawTrainable<IsolationTree> {
     var leftIndices = range(0, feature.columns()).parallel()
         .filter(idx -> feature.getDouble(idx) < valueSplit)
         .toArray();
-    var left = matrix.getRows(leftIndices);
+    var left = getVector(matrix, leftIndices);
 
     var rightIndices = range(0, feature.columns()).parallel()
         .filter(idx -> feature.getDouble(idx) > valueSplit)
         .toArray();
-    var right = matrix.getRows(rightIndices);
+    var right = getVector(matrix, rightIndices);
 
     return new IsolationNode(
         splitFeature,
@@ -58,6 +59,10 @@ public class IsolationTree implements RawTrainable<IsolationTree> {
         buildTree(left, currentDepth - 1),
         buildTree(right, currentDepth - 1)
     );
+  }
+
+  private INDArray getVector(INDArray matrix, long[] indices) {
+    return matrix.get(NDArrayIndex.indices(indices));
   }
 
   private double getValueSplit(double startInclusive, double endInclusive) {


### PR DESCRIPTION
This PR enables PCR without going through dataframes.

It also fixes a bug on IsolationForest when trying to get empty indices on a single vector.